### PR TITLE
add numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 spidev
 gpiozero
 pyaudio
+numpy


### PR DESCRIPTION
`numpy` was missing but is for instance used in the `recording_examples/record_one_channel.py`.